### PR TITLE
Support for specifying GET query string params

### DIFF
--- a/gocardless/client.py
+++ b/gocardless/client.py
@@ -62,13 +62,14 @@ class Client(object):
         if merchant_id:
             self._merchant_id = merchant_id
 
-    def api_get(self, path, **kwargs):
+    def api_get(self, path, params=None, **kwargs):
         """
         Issue an GET request to the API server.
 
         :param path: the path that will be added to the API prefix
+        :param params: query string parameters
         """
-        return self._request('get', API_PATH + path, **kwargs)
+        return self._request('get', API_PATH + path, params=params, **kwargs)
 
     def api_post(self, path, data, **kwargs):
         """Issue a POST request to the API server
@@ -92,7 +93,6 @@ class Client(object):
         """Issue a delete to the API server.
 
         :param path: the path that will be added to the API prefix
-        :param params: query string parameters
         """
         return self._request('delete', API_PATH + path, **kwargs)
 
@@ -104,7 +104,7 @@ class Client(object):
         :param path: the path fragment of the URL
         """
         request_url = self.get_base_url() + path
-        request = Request(method, request_url)
+        request = Request(method, request_url, params=kwargs.get("params"))
         logger.debug("Executing request to {0}".format(request_url))
 
         if 'auth' in kwargs:

--- a/gocardless/request.py
+++ b/gocardless/request.py
@@ -5,7 +5,7 @@ import requests
 
 class Request(object):
 
-    def __init__(self, method, url):
+    def __init__(self, method, url, params=None):
         self._method = method
         self._url = url
         headers = {}
@@ -13,6 +13,9 @@ class Request(object):
         lib_version = gocardless.get_version()
         headers["User-Agent"] = "gocardless-python/{0}".format(lib_version)
         self._opts = {"headers": headers}
+
+        if params is not None:
+            self._opts["params"] = params
 
         if not self._valid_method(method):
             raise ValueError('Invalid method {0}'.format(method))

--- a/gocardless/resources.py
+++ b/gocardless/resources.py
@@ -62,8 +62,8 @@ class Resource(object):
                     # creator, see
                     # http://stackoverflow.com/questions/233673/
                     #         lexical-closures-in-python/235764#235764
-                    def get_resources(inst):
-                        data = inst.client.api_get(the_path)
+                    def get_resources(inst, **params):
+                        data = inst.client.api_get(the_path, params=params)
                         return [the_klass(attrs, self.client) for attrs in data]
                     return get_resources
                 res_func = create_get_resource_func(path, sub_klass)
@@ -189,7 +189,7 @@ class Bill(Resource):
 
     """Please note the refund endpoint is disabled by default
 
-    If you have over 50 successful payments on your account and you 
+    If you have over 50 successful payments on your account and you
     require access to the refund endpoint, please email help@gocardless.com
     """
     def refund(self):

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -47,6 +47,15 @@ class RequestTestCase(unittest.TestCase):
         mock_requests.get.assert_called_once_with(mock.ANY, headers=mock.ANY)
 
     @mock.patch('gocardless.request.requests')
+    def test_perform_passes_params_through(self, mock_requests):
+        params = {'x': 'y'}
+        request = gocardless.request.Request('get', 'http://test.com', params)
+        mock_requests.get.return_value.content = '{"a": "b"}'
+        request.perform()
+        mock_requests.get.assert_called_once_with(mock.ANY, headers=mock.ANY,
+                                                  params=params)
+
+    @mock.patch('gocardless.request.requests')
     def test_perform_calls_post_for_posts(self, mock_requests):
         mock_requests.post.return_value.content = '{"a": "b"}'
         self.request._method = 'post'

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -98,6 +98,13 @@ class ResourceSubresourceTestCase(unittest.TestCase):
             self.assertIsInstance(res, TestSubResource)
         self.assertEqual(set([1,2]), set([item.id for item in result]))
 
+    def test_resource_can_query_subresource_with_params(self):
+        mock_client = mock.Mock()
+        mock_client.api_get.return_value = [create_mock_attrs({"id":"1"})]
+        self.resource.client = mock_client
+        result = self.resource.test_sub_resources(foo='bar')
+        mock_client.api_get.assert_called_with(mock.ANY, params={'foo': 'bar'})
+
     def test_resource_is_correct_instance(self):
         """
         Expose an issue where the closure which creates sub_resource functions


### PR DESCRIPTION
- Add `params` as an optional parameter to the `Request` object's
  constructor
- `params` passed to `Client.api_get` are passed to the `Request` object
- Any keyword args passed to subresource query methods are passed as
  params into `Client.api_get`