### PR TITLE
Python3 support

### DIFF
--- a/gocardless/__init__.py
+++ b/gocardless/__init__.py
@@ -29,7 +29,7 @@ def get_version():
 from .client import Client
 
 #import as clientlib so that we don't shadow with the client variable
-import client as clientlib
+from . import client as clientlib
 from gocardless.resources import (Bill, Subscription, PreAuthorization, User,
                                   Merchant)
 

--- a/gocardless/request.py
+++ b/gocardless/request.py
@@ -37,5 +37,5 @@ class Request(object):
     def perform(self):
         fetch_func = getattr(requests, self._method)
         response = fetch_func(self._url, **self._opts)
-        return json.loads(response.content)
+        return response.json()
 

--- a/gocardless/urlbuilder.py
+++ b/gocardless/urlbuilder.py
@@ -1,7 +1,7 @@
 import base64
 import datetime
 import os
-import utils
+from . import utils
 
 
 class UrlBuilder(object):
@@ -106,6 +106,7 @@ class PreAuthorizationParams(object):
 
         self.setup_fee = setup_fee
 
+        interval_length = int(interval_length)
         if not interval_length > 0:
             raise ValueError("interval_length must be positive, value "
                              "passed was {0}".format(interval_length))
@@ -146,7 +147,7 @@ class PreAuthorizationParams(object):
         attrnames = [
             "merchant_id", "name", "description", "interval_count",
             "interval_unit", "interval_length", "max_amount",
-            "calendar_intervals", "expires_at", "user", "setup_fee", 
+            "calendar_intervals", "expires_at", "user", "setup_fee",
             "currency"
         ]
         for attrname in attrnames:
@@ -161,7 +162,7 @@ class BillParams(BasicParams):
     def __init__(self, amount, merchant_id, name=None, description=None,
                  user=None, currency=None):
         BasicParams.__init__(self, amount, merchant_id, name=name,
-                             user=user, description=description, 
+                             user=user, description=description,
                              currency=currency)
         self.resource_name = "bills"
 
@@ -170,13 +171,14 @@ class SubscriptionParams(BasicParams):
 
     def __init__(self, amount, merchant_id, interval_length, interval_unit,
                  name=None, description=None, start_at=None, expires_at=None,
-                 interval_count=None, user=None, setup_fee=None, 
+                 interval_count=None, user=None, setup_fee=None,
                  currency=None):
         BasicParams.__init__(self, amount, merchant_id, user=user,
                              description=description, name=name)
         self.resource_name = "subscriptions"
         self.merchant_id = merchant_id
 
+        interval_length = int(interval_length)
         if not interval_length > 0:
             raise ValueError("interval_length must be positive, value "
                              "passed was {0}".format(interval_length))
@@ -213,7 +215,7 @@ class SubscriptionParams(BasicParams):
 
         self.attrnames.extend([
             "description", "interval_count", "interval_unit",
-            "interval_length", "expires_at", "start_at", "setup_fee", 
+            "interval_length", "expires_at", "start_at", "setup_fee",
             "currency"
         ])
 

--- a/gocardless/utils.py
+++ b/gocardless/utils.py
@@ -1,26 +1,31 @@
-import urllib
 import hashlib
 import hmac
 import re
 
+import six
+try:
+    from urllib import quote
+except ImportError:
+    from six.moves.urllib.parse import quote
+
 
 def percent_encode(string):
     """A version of urllibs' quote which correctly quotes '~'"""
-    return urllib.quote(string.encode('utf-8'), '~')
+    return quote(string.encode('utf-8'), '~')
 
 
 def to_query(obj, ns=None):
     """Create a query string from a list or dictionary"""
     if isinstance(obj, dict):
-        pairs = sum((to_query(v, u"{0}[{1}]".format(ns, k) if ns else k)
-                     for k, v in obj.items()), [])
+        pairs = sum((to_query(v, six.u("{0}[{1}]".format(ns, k)) if ns else k)
+                     for k, v in six.iteritems(obj)), [])
         if ns:
             return pairs
-        return u"&".join(u"{0}={1}".format(*p) for p in sorted(pairs))
+        return "&".join(six.u("{0}={1}".format(*p)) for p in sorted(pairs))
     elif isinstance(obj, (list, tuple)):
-        return sum((to_query(v, u"{0}[]".format(ns)) for v in obj), [])
+        return sum((to_query(v, six.u("{0}[]".format(ns))) for v in obj), [])
     else:
-        return [(percent_encode(unicode(ns)), percent_encode(unicode(obj)))]
+        return [(percent_encode(six.text_type(ns)), percent_encode(six.text_type(obj)))]
 
 
 def generate_signature(data, secret):
@@ -29,7 +34,9 @@ def generate_signature(data, secret):
     and your application's secret, returning a HMAC-SHA256
     digest of the data.
     """
-    return hmac.new(secret, to_query(data), hashlib.sha256).hexdigest()
+    return hmac.new(six.b(secret),
+                    msg=six.b(to_query(data)),
+                    digestmod=hashlib.sha256).hexdigest()
 
 
 def signature_valid(data, secret):

--- a/gocardless/utils.py
+++ b/gocardless/utils.py
@@ -3,10 +3,7 @@ import hmac
 import re
 
 import six
-try:
-    from urllib import quote
-except ImportError:
-    from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import quote
 
 
 def percent_encode(string):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mock==1.0.1
 nose==1.3.4
 requests==2.4.3
+six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock==1.0.1
 nose==1.3.4
-requests==2.4.3
+requests>=1.0.0
 six==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
     classifiers=CLASSIFIERS,
-    install_requires=['requests>=1.0.0'],
+    install_requires=['requests>=1.0.0', 'six==1.9.0'],
     test_suite='test',
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
     classifiers=CLASSIFIERS,
-    install_requires=['requests'],
+    install_requires=['requests>=1.0.0'],
     test_suite='test',
 )

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -7,15 +7,17 @@ from mock import patch
 import os
 import sys
 import time
-import urlparse
 
-import fixtures
+import six
+from six.moves import urllib
+
+from . import fixtures
 import gocardless
 import gocardless.client
 from gocardless.client import Client
 from gocardless import utils, urlbuilder, resources
 from gocardless.exceptions import SignatureError, ClientError
-from test_resources import create_mock_attrs
+from .test_resources import create_mock_attrs
 
 mock_account_details = {
     'app_id': 'id01',
@@ -33,8 +35,8 @@ def create_mock_client(details):
 
 
 def get_url_params(url):
-    param_dict = urlparse.parse_qs(urlparse.urlparse(url).query)
-    return dict([[k,v[0]] for k,v in param_dict.items()])
+    param_dict = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+    return dict([[k,v[0]] for k,v in six.iteritems(param_dict)])
 
 
 class ClientTestCase(unittest.TestCase):
@@ -50,8 +52,8 @@ class ClientTestCase(unittest.TestCase):
             mock_request_module.return_value = mock_request
             with self.assertRaises(ClientError) as ex:
                 self.client.api_get("/somepath")
-            self.assertEqual(ex.exception.message, "Error calling api, message"
-                " was anerrormessage")
+                self.assertEqual(six.text_type(ex), "Error calling api, message"
+                    " was anerrormessage")
 
     def test_error_when_result_is_list(self):
         #Test for an issue where the code which checked if
@@ -211,8 +213,8 @@ class UrlBuilderTestCase(unittest.TestCase):
         return mock_params
 
     def get_url_params(self, url):
-        param_dict = urlparse.parse_qs(urlparse.urlparse(url).query)
-        return dict([[k,v[0]] for k,v in param_dict.items()])
+        param_dict = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        return dict([[k,v[0]] for k,v in six.iteritems(param_dict)])
 
     def test_urlbuilder_url_contains_correct_parameters(self):
         params = self.make_mock_params({"resource_name": "bill",
@@ -220,7 +222,7 @@ class UrlBuilderTestCase(unittest.TestCase):
                     "merchant_id":"merchid"})
         url = self.urlbuilder.build_and_sign(params)
         urlparams = get_url_params(url)
-        for k,v in params.to_dict().items():
+        for k,v in six.iteritems(params.to_dict()):
             if k == "resource_name":
                 continue
             self.assertEqual(urlparams["bill[{0}]".format(k)], str(v))
@@ -230,7 +232,7 @@ class UrlBuilderTestCase(unittest.TestCase):
                 "amount":20.0})
         url = self.urlbuilder.build_and_sign(params)
         urlparams = get_url_params(url)
-        self.assertTrue(urlparams.has_key("bill[amount]"))
+        self.assertTrue("bill[amount]" in urlparams)
 
 
     def test_add_merchant_id_to_limit(self):
@@ -281,7 +283,7 @@ class UrlBuilderTestCase(unittest.TestCase):
     def test_url_contains_resource_name(self):
         params = self.make_mock_params({"resource_name" : "pre_authorizations"})
         url = self.urlbuilder.build_and_sign(params)
-        path = urlparse.urlparse(url).path
+        path = urllib.parse.urlparse(url).path
         self.assertEqual(path, "/connect/pre_authorizations/new")
 
     def test_url_contains_timestamp(self):

--- a/test/test_params.py
+++ b/test/test_params.py
@@ -1,7 +1,9 @@
 import datetime
 import mock
 import unittest
-import urlparse
+
+import six
+from six.moves import urllib
 
 import gocardless
 from gocardless import utils, urlbuilder
@@ -103,13 +105,13 @@ class PreAuthParamsToDictTestCase(unittest.TestCase):
         return pa
 
     def assert_inverse(self, keys):
-        params = dict([[k,v] for k,v in self.all_params.items() \
+        params = dict([[k,v] for k,v in six.iteritems(self.all_params) \
                 if k in keys])
         pa = self.create_from_params_dict(params)
         self.assertEqual(params, pa.to_dict())
 
     def test_to_dict_all_params(self):
-        self.assert_inverse(self.all_params.keys())
+        self.assert_inverse(list(self.all_params.keys()))
 
     def test_to_dict_only_required(self):
         self.assert_inverse(self.required_keys)

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -56,7 +56,7 @@ class RequestTestCase(unittest.TestCase):
     @mock.patch('gocardless.request.requests.get')
     def test_perform_decodes_json(self, mock_get):
         response = mock.Mock()
-        response.content = '{"a": "b"}'
+        response.json = lambda: {"a": "b"}
         mock_get.return_value = response
         self.assertEqual(self.request.perform(), {'a': 'b'})
 

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -5,9 +5,12 @@ import mock
 from mock import patch
 import unittest
 
-import fixtures
+import six
+
+from . import fixtures
 import gocardless
 from gocardless.resources import Resource, Subscription, Bill, PreAuthorization
+import collections
 
 
 class TestResource(Resource):
@@ -53,7 +56,7 @@ class ResourceTestCase(unittest.TestCase):
                 "key3":"three",
                 "id":"1"}
         res = TestResource(attrs.copy(), None)
-        for key, value in attrs.items():
+        for key, value in six.iteritems(attrs):
             self.assertEqual(getattr(res, key), value)
 
     def test_resource_created_at_is_date(self):
@@ -86,10 +89,10 @@ class ResourceSubresourceTestCase(unittest.TestCase):
 
     def test_resource_lists_subresources(self):
         self.assertTrue(hasattr(self.resource, "test_sub_resources"))
-        self.assertTrue(callable(getattr(self.resource, "test_sub_resources")))
+        self.assertTrue(isinstance(getattr(self.resource, "test_sub_resources"), collections.Callable))
 
     def test_resource_subresource_returns_subresource_instances(self):
-        mock_return = map(create_mock_attrs, [{"id":1},{"id":2}])
+        mock_return = list(map(create_mock_attrs, [{"id":1},{"id":2}]))
         mock_client = mock.Mock()
         mock_client.api_get.return_value = mock_return
         self.resource.client = mock_client

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import unittest
+import six
 
 
 from gocardless import utils
@@ -9,34 +10,42 @@ from gocardless import utils
 class PercentEncodeTestCase(unittest.TestCase):
 
     def test_works_with_empty_strings(self):
-      self.assertEqual(utils.percent_encode(u""), u"")
+      self.assertEqual(utils.percent_encode(six.u("")), six.u(""))
 
     def test_doesnt_encode_lowercase_alpha_characters(self):
-      self.assertEqual(utils.percent_encode(u"abcxyz"), u"abcxyz")
+      self.assertEqual(utils.percent_encode(six.u("abcxyz")), six.u("abcxyz"))
 
     def test_doesnt_encode_uppercase_alpha_characters(self):
-      self.assertEqual(utils.percent_encode(u"ABCXYZ"), u"ABCXYZ")
+      self.assertEqual(utils.percent_encode(six.u("ABCXYZ")), six.u("ABCXYZ"))
 
     def test_doesnt_encode_digits(self):
-      self.assertEqual(utils.percent_encode(u"1234567890"), u"1234567890")
+      self.assertEqual(utils.percent_encode(six.u("1234567890")), six.u("1234567890"))
 
     def test_doesnt_encode_unreserved_non_alphanum_chars(self):
-      self.assertEqual(utils.percent_encode(u"-._~"), u"-._~")
+      self.assertEqual(utils.percent_encode(six.u("-._~")), six.u("-._~"))
 
     def test_encodes_non_ascii_alpha_characters(self):
-      self.assertEqual(utils.percent_encode(u"å"), u"%C3%A5")
+      if six.PY2:
+          original = u"å"
+      else:
+          original = "å"
+      self.assertEqual(utils.percent_encode(original), six.u("%C3%A5"))
 
     def test_encodes_reserved_ascii_characters(self):
-      self.assertEqual(utils.percent_encode(u" !\"#$%&'()"),
-                       u"%20%21%22%23%24%25%26%27%28%29")
-      self.assertEqual(utils.percent_encode(u"*+,/{|}:;"),
-                       u"%2A%2B%2C%2F%7B%7C%7D%3A%3B")
-      self.assertEqual(utils.percent_encode(u"<=>?@[\\]^`"),
-                       u"%3C%3D%3E%3F%40%5B%5C%5D%5E%60")
+      self.assertEqual(utils.percent_encode(six.u(" !\"#$%&'()")),
+                       six.u("%20%21%22%23%24%25%26%27%28%29"))
+      self.assertEqual(utils.percent_encode(six.u("*+,/{|}:;")),
+                       six.u("%2A%2B%2C%2F%7B%7C%7D%3A%3B"))
+      self.assertEqual(utils.percent_encode(six.u("<=>?@[\\]^`")),
+                       six.u("%3C%3D%3E%3F%40%5B%5C%5D%5E%60"))
 
     def test_encodes_other_non_ascii_characters(self):
-      self.assertEqual(utils.percent_encode(u"支払い"),
-                       u"%E6%94%AF%E6%89%95%E3%81%84")
+      if six.PY2:
+          original = u"支払い"
+      else:
+          original = "支払い"
+      self.assertEqual(utils.percent_encode(original),
+                       six.u("%E6%94%AF%E6%89%95%E3%81%84"))
 
 
 class SignatureTestCase(unittest.TestCase):
@@ -46,7 +55,7 @@ class SignatureTestCase(unittest.TestCase):
       self.client_id = '4jqkF9tirkr3zfWCgEKxLDy3UmF1sWpHPVm8X69yiB7Lqb63usVOPzrm0jEepc5R'
 
     def test_hmac(self):
-      # make sure our signature function 
+      # make sure our signature function
       # works correctly
       sig = utils.generate_signature({"foo": "bar", "example": [1, "a"]},self.secret)
       self.assertEqual(sig, '5a9447aef2ebd0e12d80d80c836858c6f9c13219f615ef5d135da408bcad453d')
@@ -58,7 +67,7 @@ class SignatureTestCase(unittest.TestCase):
         self.assertTrue(utils.signature_valid(params, self.secret))
         params["signature"] = "123482494523435"
         self.assertFalse(utils.signature_valid(params, self.secret))
-    
+
 
 class CamelizeTestCase(unittest.TestCase):
     def test_camelize_multi_word(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,6 +2,7 @@
 
 import unittest
 import six
+import codecs
 
 
 from gocardless import utils
@@ -25,10 +26,10 @@ class PercentEncodeTestCase(unittest.TestCase):
       self.assertEqual(utils.percent_encode(six.u("-._~")), six.u("-._~"))
 
     def test_encodes_non_ascii_alpha_characters(self):
-      if six.PY2:
-          original = u"å"
-      else:
+      if six.PY3:
           original = "å"
+      else:
+          original = codecs.lookup('utf-8').decode("å")[0]
       self.assertEqual(utils.percent_encode(original), six.u("%C3%A5"))
 
     def test_encodes_reserved_ascii_characters(self):
@@ -40,10 +41,10 @@ class PercentEncodeTestCase(unittest.TestCase):
                        six.u("%3C%3D%3E%3F%40%5B%5C%5D%5E%60"))
 
     def test_encodes_other_non_ascii_characters(self):
-      if six.PY2:
-          original = u"支払い"
-      else:
+      if six.PY3:
           original = "支払い"
+      else:
+          original = codecs.lookup('utf-8').decode("支払い")[0]
       self.assertEqual(utils.percent_encode(original),
                        six.u("%E6%94%AF%E6%89%95%E3%81%84"))
 


### PR DESCRIPTION
This should be a compatible version with both Python 2 and 3. Have used `six` when possible to maintain compatibility, and only explicitly forked code when required (`six.u()` does not seem to be exactly the same as `u" "` when it comes to non-ASCII characters). Tests updated and passing as well.