### PR TITLE
Push people towards the Pro API and library

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,53 @@
+[![GoCardless Python Client Library](https://s3-eu-west-1.amazonaws.com/gocardless/images/client-lib-headers/python-lib-header.png)](https://gocardless.com/docs?language=python)
+
+[![Build Status](https://secure.travis-ci.org/gocardless/gocardless-python.png?branch=master)](http://travis-ci.org/gocardless/gocardless-python)
+
+This module provides a wrapper around the GoCardless payments API, the
+interface to the api is provided by the `gocardless.Client` object. See the
+documentation for that class for how to obtain an instance.
+
+By default the library will attempt to use the GoCardless production
+environment, for testing purposes this is not what you want and you should set
+the `gocardless.environment` to "sandbox".::
+
+    >>> gocardless.environment = "sandbox"
+
+Set your account details:::
+    
+    >>> gocardless.set_details(app_id="kzCOPw2JtJvRQxKOPEREQTGvxLvkoMS1Eb0Dgl5QVc1W0NKpOEZDvESfGOI_kkG2l",
+    >>>     app_secret="IO9AlgPsbYNCtFlcOFGROBrGB3Mi07PFYSn2zx4uK5xaWJI1AzwnYeC86x46ji_g",
+    >>>     access_token="5EFkzOrUOZ8t+iaP86NggIy+FOFSD0f7QMnMd+Q3P4mQk17Kzq9G1vYrNlEWFldlg",
+    >>>     merchant_id="02FX1YFDAS")
+
+You can now use the `gocardless.client` object to generate urls for receiving payments.::
+
+    >>> gocardless.client.new_bill_url(10)
+
+Users who click on this link will be taken to the GoCardless website to make a payment to 
+your account.
+
+You can also use it to query the api for information about payments resources using an 
+active resource style API. For example, to get all of a merchants bills::
+
+    >>> merchant = client.merchant()
+    >>> merchant.bills()
+    >>> [<gocardless.resources.Bill at 0x29a6050>]
+
+Contribute
+==========
+
+Fork the repo then clone it to your machine and install in "develop" mode
+(preferably using a virtualenv)::
+
+    mkvirtualenv gocardless
+    git clone https://github.com/<username>/gocardless-python
+    cd gocardless-python
+    python setup.py develop
+
+Install the testing dependencies::
+
+    pip install -r requirements.txt
+
+and run the test suite::
+
+    nosetests

--- a/README.md
+++ b/README.md
@@ -1,53 +1,9 @@
 [![GoCardless Python Client Library](https://s3-eu-west-1.amazonaws.com/gocardless/images/client-lib-headers/python-lib-header.png)](https://gocardless.com/docs?language=python)
 
-[![Build Status](https://secure.travis-ci.org/gocardless/gocardless-python.png?branch=master)](http://travis-ci.org/gocardless/gocardless-python)
+__This API library is only for developers who already have an integration using the [Legacy GoCardless API](https://developer.gocardless.com/legacy).__
 
-This module provides a wrapper around the GoCardless payments API, the
-interface to the api is provided by the `gocardless.Client` object. See the
-documentation for that class for how to obtain an instance.
+If you're starting a new integration, you should use the new [GoCardless API](https://developer.gocardless.com) with the [gocardless-pro-python](https://github.com/gocardless/gocardless-pro-python) library.
 
-By default the library will attempt to use the GoCardless production
-environment, for testing purposes this is not what you want and you should set
-the `gocardless.environment` to "sandbox".::
+If you're not sure whether this is the right library for you, get in touch - you can reach our developer support team at <api@gocardless.com>.
 
-    >>> gocardless.environment = "sandbox"
-
-Set your account details:::
-    
-    >>> gocardless.set_details(app_id="kzCOPw2JtJvRQxKOPEREQTGvxLvkoMS1Eb0Dgl5QVc1W0NKpOEZDvESfGOI_kkG2l",
-    >>>     app_secret="IO9AlgPsbYNCtFlcOFGROBrGB3Mi07PFYSn2zx4uK5xaWJI1AzwnYeC86x46ji_g",
-    >>>     access_token="5EFkzOrUOZ8t+iaP86NggIy+FOFSD0f7QMnMd+Q3P4mQk17Kzq9G1vYrNlEWFldlg",
-    >>>     merchant_id="02FX1YFDAS")
-
-You can now use the `gocardless.client` object to generate urls for receiving payments.::
-
-    >>> gocardless.client.new_bill_url(10)
-
-Users who click on this link will be taken to the GoCardless website to make a payment to 
-your account.
-
-You can also use it to query the api for information about payments resources using an 
-active resource style API. For example, to get all of a merchants bills::
-
-    >>> merchant = client.merchant()
-    >>> merchant.bills()
-    >>> [<gocardless.resources.Bill at 0x29a6050>]
-
-Contribute
-==========
-
-Fork the repo then clone it to your machine and install in "develop" mode
-(preferably using a virtualenv)::
-
-    mkvirtualenv gocardless
-    git clone https://github.com/<username>/gocardless-python
-    cd gocardless-python
-    python setup.py develop
-
-Install the testing dependencies::
-
-    pip install -r requirements.txt
-
-and run the test suite::
-
-    nosetests
+If you're sure this is the library you want to be using, see [DOCUMENTATION.md](https://github.com/gocardless/gocardless-python/blob/master/DOCUMENTATION.md) for documentation and helpful resources.


### PR DESCRIPTION
This API library is not suitable for people starting integrations, who should be using the new [GoCardless API](https://developer.gocardless.com/2015-07-06/#overview) with the [gocardless-pro-python](https://github.com/gocardless/gocardless-pro-python) library.

This makes that clear by making the README.md say *just* this, and linking you through to a new DOCUMENTATION.md to see the old content.